### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
      - uses: actions/checkout@main
      - name: Publish to registy
-       uses: elgohr/Publish-Docker-Github-Action@main
+       uses: elgohr/Publish-Docker-Github-Action@v5
        with:
         registry: ghcr.io
         name: ghcr.io/RidiculousCircumstances/ratingapp-purple-school/ratingapp-purple-school


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore